### PR TITLE
Improve mobile & input form width

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -89,6 +89,7 @@ li[class*='_route']>span:hover {
 #dlForm {
     display: table;
     border-spacing: 0px 10px;
+    width: 100%;
 }
 
 .input-table>div {
@@ -101,6 +102,10 @@ li[class*='_route']>span:hover {
 
 .input-table>div>input {
     display: table-cell;
+}
+
+.input-table>div>input[type="text"] {
+    width: 100%;
 }
 
 .sidebar-header {

--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, target-densitydpi=high-dpi, user-scalable=no, initial-scale=1, minimum-scale=1, maximum-scale=1" />
+    <meta name="HandheldFriendly" content="true" />
     <title>OSM Public Transport Map</title>
     <link rel="stylesheet" href="lib/leaflet/leaflet.css" />
     <link rel="stylesheet" href="lib/font-awesome/css/font-awesome.min.css">


### PR DESCRIPTION
I added some meta tags to make mobile devices use mobile view and forced the input form to use the full width of the panel.
